### PR TITLE
Unbundle Cloth Config

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,7 @@ dependencies {
     mappings   "net.fabricmc:yarn:${Versions['yarn_mappings']}:v2"
     modImplementation "net.fabricmc:fabric-loader:${Versions['loader_version']}"
     modImplementation "net.fabricmc.fabric-api:fabric-api:${Versions['fabric_version']}"
-    modImplementation include ("me.shedaniel.cloth:cloth-config-fabric:7.0.73") {
+    modApi("me.shedaniel.cloth:cloth-config-fabric:7.0.73") {
         exclude(group: "net.fabricmc.fabric-api")
     }
     modCompileOnly "com.terraformersmc:modmenu:${Versions['modmenu_version']}"


### PR DESCRIPTION
Fixes #25 
[The dependency already exists](https://github.com/gbl/AdvancementInfo/blob/fabric_1_19/src/main/resources/fabric.mod.json#L20), so that was not included in the PR.
[Based on the API's own instructions](https://shedaniel.gitbook.io/cloth-config/setup-cloth-config/cloth-config-fabric).